### PR TITLE
Message as Strings

### DIFF
--- a/src/model/message.re
+++ b/src/model/message.re
@@ -1,4 +1,1 @@
-type t = ..;
-type t +=
-  | Debug(string)
-  | Exit_signal;
+type t = string;

--- a/src/model/message.rei
+++ b/src/model/message.rei
@@ -1,4 +1,1 @@
-type t = ..;
-type t +=
-  | Debug(string)
-  | Exit_signal;
+type t = string;

--- a/src/model/process.re
+++ b/src/model/process.re
@@ -2,7 +2,7 @@ type behavior('s) = [ | `Become('s) | `Terminate];
 
 type env('s) = {
   self: unit => Pid.t,
-  recv: unit => option(Message.t),
+  recv: unit => option(string),
 };
 
 type task('s) = (env('s), 's) => behavior('s);

--- a/src/model/process.rei
+++ b/src/model/process.rei
@@ -2,7 +2,7 @@ type behavior('s) = [ | `Become('s) | `Terminate];
 
 type env('s) = {
   self: unit => Pid.t,
-  recv: unit => option(Message.t),
+  recv: unit => option(string),
 };
 
 type task('s) = (env('s), 's) => behavior('s);
@@ -11,6 +11,6 @@ type t;
 
 let send: (t, Message.t) => unit;
 
-let recv: (t, unit) => option(Message.t);
+let recv: (t, unit) => option(string);
 
 let make: Pid.t => t;

--- a/test/runtime/runtime_test.re
+++ b/test/runtime/runtime_test.re
@@ -17,14 +17,8 @@ module Test_actor = {
   module Message = {
     type t = [ | `Hola];
 
-    let encode =
-      fun
-      | `Hola => "Hola";
-
-    let decode =
-      fun
-      | "Hola" => Some(`Hola)
-      | _ => None;
+    let encode: t => string = x => Marshal.to_string(x, []);
+    let decode: string => t = x => Marshal.from_string(x, 0);
 
     let say_hi = pid => pid <- (`Hola |> encode);
   };
@@ -35,8 +29,7 @@ module Test_actor = {
       switch (env.recv()) {
       | Some(msg) =>
         switch (msg |> Message.decode) {
-        | Some(`Hola) => Logs.app(m => m("Hola!"))
-        | _ => ()
+        | `Hola => Logs.app(m => m("Hola!"))
         };
         `Become(state);
       | _ => `Become(state)


### PR DESCRIPTION
For the time being, and to unlock more feature building, I'm typing all
messages as `string`.

This means it's up to actors to do encoding/decoding of whatever
invariants they require into it.

This is subject to change, as I'm looking into more idiomatic ways of
handling this.